### PR TITLE
encode before calling btoa

### DIFF
--- a/content.js
+++ b/content.js
@@ -9,6 +9,13 @@ function isDuplicate(dataArray, dataObject){
     return false;
 }
 
+function b64EncodeUnicode(str) {
+    return btoa(encodeURIComponent(str).replace(/%([0-9A-F]{2})/g,
+        function toSolidBytes(match, p1) {
+            return String.fromCharCode('0x' + p1);
+    }));
+}
+
 function processSVG (element, elementOuterHTML){
     var imageTitle,
         titleSearch = elementOuterHTML.match(/<title>([\S]+)<\/title>/),
@@ -47,7 +54,7 @@ function processSVG (element, elementOuterHTML){
         title: imageTitle,
         width: imageWidth,
         height: imageHeight,
-        src: "data:image/svg+xml;base64,"+window.btoa(elementOuterHTML)
+        src: "data:image/svg+xml;base64,"+b64EncodeUnicode(elementOuterHTML)
     }
 
 }


### PR DESCRIPTION
Some websites throw error when processing svg  
```
content.js:72 Uncaught DOMException: Failed to execute 'btoa' on 'Window': The string to be encoded contains characters outside of the Latin1 range.
    at processSVG 
```
As explained in https://developer.mozilla.org/en/docs/Web/API/WindowBase64/Base64_encoding_and_decoding
"In most browsers, calling btoa() on a Unicode string will cause a Character Out Of Range exception. "
`b64EncodeUnicode` is taken from the same link


for replication error check console log on this link
https://icons8.com/icon/set/menu/color#bottomIconInColl